### PR TITLE
Add build_tool option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - Support building and uploading multiple binaries at the same step. ([#17](https://github.com/taiki-e/upload-rust-binary-action/pull/17))
 
+- Add `build_tool` input option to specify the tool to build binaries.
+
 ## [1.5.0] - 2022-07-05
 
 - Add `include` input option to include additional files. ([#17](https://github.com/taiki-e/upload-rust-binary-action/pull/17))

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: Whether to create the leading directory in the archive or not
     required: false
     default: 'false'
+  build_tool:
+    description: Tool to build binaries (cargo or cross)
+    required: false
 
 runs:
   using: node16


### PR DESCRIPTION
Follow-up of #16.

This adds `build_tool` input option to specify the tool to build binaries.

This option currently supports only `cargo` and `cross`, but may support `cargo-zigbuild` or others in the future.