### PR TITLE
Support manifest path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently, this action is basically intended to be used in combination with an a
 | leading_dir         | false        | Whether to create the leading directory in the archive or not                                | Boolean | `false`        |
 | build_tool          | false        | Tool to build binaries (cargo or cross, see [cross-compilation example](#example-workflow-cross-compilation) for more) | String |                |
 | ref                 | false        | Fully-formed tag ref for this release (see [action.yml](action.yml) for more)                | String  |                |
+| manifest_path       | false        | Path to Cargo.toml                                                                           | String  | `Cargo.toml`   |
 
 [^1]: Required one of `token` input option or `GITHUB_TOKEN` environment variable.
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: Whether to disable cargo build default features
     required: false
     default: 'false'
+  manifest_path:
+    description: Override cargo manifest path
+    required: false
   tar:
     description: On which platform to distribute the `.tar.gz` file (all, unix, windows, or none)
     required: false

--- a/main.sh
+++ b/main.sh
@@ -197,6 +197,10 @@ fi
 if [[ -n "${no_default_features}" ]]; then
     build_options+=("--no-default-features")
 fi
+manifest_path="${INPUT_MANIFEST_PATH:-}"
+if [[ -n "${manifest_path}" ]]; then
+    build_options+=("--manifest-path" "${manifest_path}")
+fi
 
 case "${build_tool}" in
     cargo) cargo build "${build_options[@]}" ;;

--- a/main.sh
+++ b/main.sh
@@ -200,7 +200,7 @@ fi
 manifest_path="${INPUT_MANIFEST_PATH:-}"
 if [[ -n "${manifest_path}" ]]; then
     build_options+=("--manifest-path" "${manifest_path}")
-    build_options+=("--target-dir" "target")
+    build_options+=("--target-dir" "${RUNNER_TEMP}/target")
 fi
 
 case "${build_tool}" in

--- a/main.sh
+++ b/main.sh
@@ -181,11 +181,7 @@ if [[ -n "${strip:-}" ]]; then
 fi
 
 build_options=("--release")
-target_dir="target/release"
-if [[ -n "${INPUT_TARGET:-}" ]]; then
-    target_dir="target/${target}/release"
-    build_options+=("--target" "${target}")
-fi
+target_dir=""
 bins=()
 for bin_name in "${bin_names[@]}"; do
     bins+=("${bin_name}${exe:-}")
@@ -200,8 +196,15 @@ fi
 manifest_path="${INPUT_MANIFEST_PATH:-}"
 if [[ -n "${manifest_path}" ]]; then
     build_options+=("--manifest-path" "${manifest_path}")
-    build_options+=("--target-dir" "${RUNNER_TEMP}/target")
-    target_dir="${RUNNER_TEMP}/${target_dir}"
+    target_dir=$(cargo metadata --format-version=1 --no-deps --manifest-path "${manifest_path}" | jq -r '."target_directory"')
+else
+    target_dir=$(cargo metadata --format-version=1 --no-deps | jq -r '."target_directory"')
+fi
+if [[ -n "${INPUT_TARGET:-}" ]]; then
+    build_options+=("--target" "${target}")
+    target_dir="${target_dir}/${target}/release"
+else
+    target_dir="${target_dir}/release"
 fi
 
 case "${build_tool}" in

--- a/main.sh
+++ b/main.sh
@@ -200,6 +200,7 @@ fi
 manifest_path="${INPUT_MANIFEST_PATH:-}"
 if [[ -n "${manifest_path}" ]]; then
     build_options+=("--manifest-path" "${manifest_path}")
+    build_options+=("--target-dir" "target")
 fi
 
 case "${build_tool}" in

--- a/main.sh
+++ b/main.sh
@@ -201,6 +201,7 @@ manifest_path="${INPUT_MANIFEST_PATH:-}"
 if [[ -n "${manifest_path}" ]]; then
     build_options+=("--manifest-path" "${manifest_path}")
     build_options+=("--target-dir" "${RUNNER_TEMP}/target")
+    target_dir="${RUNNER_TEMP}/${target_dir}"
 fi
 
 case "${build_tool}" in


### PR DESCRIPTION
This adds support for building crates that aren't in the repository's root directory.

Closes https://github.com/taiki-e/upload-rust-binary-action/issues/31