### PR TITLE
Allow wildcard in include

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,6 @@ jobs:
           # Note that glob pattern is not supported yet.
           bin: ...
           # (optional) Comma-separated list of additional files to be included to archive.
-          # Note that glob pattern is not supported yet.
           include: LICENSE,README.md
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -495,7 +494,6 @@ You can use the `leading_dir` option to create the leading directory.
     # Note that glob pattern is not supported yet.
     bin: ...
     # (optional) Comma-separated list of additional files to be included to archive.
-    # Note that glob pattern is not supported yet.
     include: LICENSE,README.md
     # (optional) Whether to create the leading directory in the archive or not. default to false.
     leading_dir: true

--- a/main.sh
+++ b/main.sh
@@ -254,14 +254,14 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         pushd "${archive}" >/dev/null
         if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.tar.gz")
-            "${tar}" acf "${cwd}/${archive}.tar.gz" "${filenames[@]}"
+            "${tar}" acf "${cwd}/${archive}.tar.gz" ${filenames[@]}
         fi
         if [[ "${INPUT_ZIP/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.zip")
             if [[ "${platform}" == "unix" ]]; then
-                zip -r "${cwd}/${archive}.zip" "${filenames[@]}"
+                zip -r "${cwd}/${archive}.zip" ${filenames[@]}
             else
-                7z a "${cwd}/${archive}.zip" "${filenames[@]}"
+                7z a "${cwd}/${archive}.zip" ${filenames[@]}
             fi
         fi
         popd >/dev/null

--- a/main.sh
+++ b/main.sh
@@ -232,7 +232,7 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         cp "${target_dir}/${bin_exe}" "${tmpdir}/${archive}"/
     done
     for include in ${includes[@]+"${includes[@]}"}; do
-        cp -r "${include}" "${tmpdir}/${archive}"/
+        cp -r ${include} "${tmpdir}/${archive}"/
         filenames+=("$(basename "${include}")")
     done
     pushd "${tmpdir}" >/dev/null

--- a/main.sh
+++ b/main.sh
@@ -236,14 +236,14 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         # /${archive}/${includes}
         if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.tar.gz")
-            "${tar}" acf "${cwd}/${archive}.tar.gz" "${archive}"
+            "${tar}" acf "${cwd}/${archive}.tar.gz" "${archive}" || true
         fi
         if [[ "${INPUT_ZIP/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.zip")
             if [[ "${platform}" == "unix" ]]; then
-                zip -r "${cwd}/${archive}.zip" "${archive}"
+                zip -r "${cwd}/${archive}.zip" "${archive}" || true
             else
-                7z a "${cwd}/${archive}.zip" "${archive}"
+                7z a "${cwd}/${archive}.zip" "${archive}" || true
             fi
         fi
     else

--- a/main.sh
+++ b/main.sh
@@ -254,14 +254,14 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         pushd "${archive}" >/dev/null
         if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.tar.gz")
-            "${tar}" acf "${cwd}/${archive}.tar.gz" ${filenames[@]}
+            "${tar}" acf "${cwd}/${archive}.tar.gz" ${filenames[@]} || true
         fi
         if [[ "${INPUT_ZIP/all/${platform}}" == "${platform}" ]]; then
             assets+=("${archive}.zip")
             if [[ "${platform}" == "unix" ]]; then
-                zip -r "${cwd}/${archive}.zip" ${filenames[@]}
+                zip -r "${cwd}/${archive}.zip" ${filenames[@]} || true
             else
-                7z a "${cwd}/${archive}.zip" ${filenames[@]}
+                7z a "${cwd}/${archive}.zip" ${filenames[@]} || true
             fi
         fi
         popd >/dev/null

--- a/main.sh
+++ b/main.sh
@@ -224,7 +224,7 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         cp "${target_dir}/${bin_exe}" "${tmpdir}/${archive}"/
     done
     for include in ${includes[@]+"${includes[@]}"}; do
-        cp -r ${include} "${tmpdir}/${archive}"/ | true
+        cp -r ${include} "${tmpdir}/${archive}"/ || true
         filenames+=("$(basename "${include}")")
     done
     pushd "${tmpdir}" >/dev/null

--- a/main.sh
+++ b/main.sh
@@ -69,14 +69,6 @@ fi
 include="${INPUT_INCLUDE:-}"
 includes=()
 if [[ -n "${include}" ]]; then
-    # We can expand a glob by expanding a variable without quote, but that way
-    # has a security issue of shell injection.
-    if [[ "${include}" == *"?"* ]] || [[ "${include}" == *"*"* ]] || [[ "${include}" == *"["* ]]; then
-        # This check is not for security but for diagnostic purposes.
-        # We quote the filename, so without this uses get an error like
-        # "cp: cannot stat 'LICENSE-*': No such file or directory".
-        bail "glob pattern in 'include' input option is not supported yet"
-    fi
     while read -rd,; do includes+=("${REPLY}"); done <<<"${include},"
 fi
 

--- a/main.sh
+++ b/main.sh
@@ -224,7 +224,7 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/
         cp "${target_dir}/${bin_exe}" "${tmpdir}/${archive}"/
     done
     for include in ${includes[@]+"${includes[@]}"}; do
-        cp -r ${include} "${tmpdir}/${archive}"/
+        cp -r ${include} "${tmpdir}/${archive}"/ | true
         filenames+=("$(basename "${include}")")
     done
     pushd "${tmpdir}" >/dev/null


### PR DESCRIPTION
This allows for syntax such as `include: target/${{ matrix.target }}/release/*example.*`  
Which covers my use-case being `libspotify.so` and `spotify.dll` in #35