### PR TITLE
Support cargo-zigbuild as build tool

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -3,3 +3,4 @@ gtar
 lipo
 mktemp
 tmpdir
+zigbuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) as build tool. ([#50](https://github.com/taiki-e/upload-rust-binary-action/pull/50))
+
 ## [1.15.0] - 2023-06-26
 
 - Use [multi-target builds](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds) for `universal-apple-darwin` (universal macOS binary) on Rust 1.64+. This could make `universal-apple-darwin` builds up to about 2x faster.

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: 'false'
   build_tool:
-    description: Tool to build binaries (cargo or cross)
+    description: Tool to build binaries (cargo, cross, or cargo-zigbuild)
     required: false
   checksum:
     description: Comma-separated list of algorithms to be used for checksum (sha256, sha512, sha1, or md5)


### PR DESCRIPTION
This supports @messense's [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) as build tool for cross-compilation.

Tested targets: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu.2.17, universal2-apple-darwin

Example: https://github.com/taiki-e/upload-rust-binary-action/tree/zigbuild#cargo-zigbuild