### PR TITLE
feat: run codesign on macOS

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -3,3 +3,4 @@ gtar
 lipo
 mktemp
 zigbuild
+codesign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,4 @@ jobs:
           tar: all
           zip: all
           manifest-path: test-crate/Cargo.toml
+          codesign: '-'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Currently, this action is basically intended to be used in combination with an a
 | manifest-path       | false        | Path to Cargo.toml                                                                           | String  | `Cargo.toml`   |
 | profile             | false        | The cargo profile to build. This defaults to the release profile.                            | String  | `release`      |
 | dry-run             | false        | Build and compress binaries, but do not upload them (see [action.yml](action.yml) for more)  | Boolean | `false`        |
+| codesign            | false        | Sign build products using `codesign` on macOS                                                | String  |                |
 
 \[1] Required one of `token` input option or `GITHUB_TOKEN` environment variable. Not required when `dry-run` input option is set to `true`.
 

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,9 @@ inputs:
     description: Alias for 'dry-run'
     required: false
     default: 'false'
+  codesign:
+    description: Sign build products using `codesign` on macOS
+    required: false
 
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
@@ -117,3 +120,4 @@ runs:
         INPUT_REF: ${{ inputs.ref }}
         INPUT_PROFILE: ${{ inputs.profile }}
         INPUT_DRY_RUN: ${{ inputs.dry-run || inputs.dry_run }}
+        INPUT_CODESIGN: ${{ inputs.codesign }}

--- a/main.sh
+++ b/main.sh
@@ -303,6 +303,14 @@ do_strip() {
         done
     fi
 }
+do_codesign() {
+    target_dir="$1"
+    if [[ -n "${INPUT_CODESIGN:-}" ]]; then
+        for bin_exe in "${bins[@]}"; do
+            x codesign --sign "${INPUT_CODESIGN}" "${target_dir}/${bin_exe}"
+        done
+    fi
+}
 
 case "${INPUT_TARGET:-}" in
     '')
@@ -335,6 +343,10 @@ case "${INPUT_TARGET:-}" in
         do_strip "${target_dir}"
         ;;
 esac
+
+if command -v codesign &> /dev/null; then
+    do_codesign "${target_dir}"
+fi
 
 if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] || [[ "${INPUT_ZIP/all/${platform}}" == "${platform}" ]]; then
     cwd=$(pwd)

--- a/main.sh
+++ b/main.sh
@@ -307,7 +307,6 @@ do_codesign() {
     target_dir="$1"
     if [[ -n "${INPUT_CODESIGN:-}" ]]; then
         for bin_exe in "${bins[@]}"; do
-            info "signing ${target_dir}/${bin_exe}"
             x codesign --sign "${INPUT_CODESIGN}" "${target_dir}/${bin_exe}"
         done
     fi

--- a/main.sh
+++ b/main.sh
@@ -307,6 +307,7 @@ do_codesign() {
     target_dir="$1"
     if [[ -n "${INPUT_CODESIGN:-}" ]]; then
         for bin_exe in "${bins[@]}"; do
+            info "signing ${target_dir}/${bin_exe}"
             x codesign --sign "${INPUT_CODESIGN}" "${target_dir}/${bin_exe}"
         done
     fi

--- a/main.sh
+++ b/main.sh
@@ -345,7 +345,7 @@ case "${INPUT_TARGET:-}" in
         ;;
 esac
 
-if command -v codesign &> /dev/null; then
+if command -v codesign &>/dev/null; then
     do_codesign "${target_dir}"
 fi
 


### PR DESCRIPTION
`codesign` is a utility used on macOS to sign binaries and add a way for the system verify their integrity after download. This PR adds an option to run the utility on binaries before uploading them to the GitHub Release. The CI has also been updated to run codesign on macOS, using an ad-hoc developer identity (`codesign --sign "-"`).

Closes #60