### PR TITLE
Work around strip bugs in rustc and cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Work around strip bugs in rustc and cargo. See [#69](https://github.com/taiki-e/upload-rust-binary-action/pull/69) for details.
+
 ## [1.19.0] - 2024-03-05
 
 - Align default strip behavior to [Cargo 1.77+'s default (strip=debuginfo)](https://github.com/rust-lang/cargo/pull/13257). See [#66](https://github.com/taiki-e/upload-rust-binary-action/pull/66) for details.


### PR DESCRIPTION
Follow-up to #66 

- Set env on pre-1.79, not pre-1.77, because it is 1.79+ that actually works correctly due to https://github.com/rust-lang/cargo/issues/13617.

- Do not strip debuginfo on MSVC https://github.com/rust-lang/cargo/pull/13630
  This is the same behavior as pre-1.19.0 upload-rust-binary-action. https://github.com/taiki-e/upload-rust-binary-action/commit/1d322553f4aa8234b1562ff50887dbbdb8c1bfd5#diff-f121df8f1f148ef72415f98dd27089a0e6cec3ec939840286358170e5e20c990L258

Closes #68 