### PR TITLE
Add support for BLAKE2 checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           bin: test-crate
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build_tool }}
-          checksum: sha256,sha512,sha1,md5
+          checksum: b2,sha256,sha512,sha1,md5
           tar: all
           zip: all
           manifest-path: test-crate/Cargo.toml
@@ -103,6 +103,9 @@ jobs:
 
           printf 'outputs.tar should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
+
+          printf 'outputs.b2 should be a file\n'
+          test -f "${{ steps.upload-rust-binary-action.outputs.b2 }}"
 
           printf 'outputs.sha256 should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.sha256 }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,19 @@ jobs:
           printf 'outputs.tar should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
 
-          matrix_checksums=${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}
-          hash_types=${matrix_checksums//,/ }
+          printf 'outputs.sha256 should be a file\n'
+          test -f "${{ steps.upload-rust-binary-action.outputs.sha256 }}"
 
-          for hash_type in $hash_types; do
-              printf "outputs.%s should be a file\n" "$hash_type"
-              test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
-          done
+          printf 'outputs.sha512 should be a file\n'
+          test -f "${{ steps.upload-rust-binary-action.outputs.sha512 }}"
+
+          printf 'outputs.sha1 should be a file\n'
+          test -f "${{ steps.upload-rust-binary-action.outputs.sha1 }}"
+
+          printf 'outputs.md5 should be a file\n'
+          test -f "${{ steps.upload-rust-binary-action.outputs.md5 }}"
+      - name: Check b2 output
+        if: ${{ contains(matrix.checksums || 'b2,sha256,sha512,sha1,md5', 'b2') }}
+        run: |
+          printf 'outputs.b2 should not be empty\n'
+          test -n "${{ steps.upload-rust-binary-action.outputs.b2 }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,20 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
           - os: macos-latest # AArch64
+            checksums: sha256,sha512,sha1,md5
           - os: macos-13 # x86_64
+            checksums: sha256,sha512,sha1,md5
           - os: macos-latest
+            checksums: sha256,sha512,sha1,md5
             target: x86_64-apple-darwin
           - os: macos-latest
+            checksums: sha256,sha512,sha1,md5
             target: aarch64-apple-darwin
           - os: macos-latest
+            checksums: sha256,sha512,sha1,md5
             target: universal-apple-darwin
           - os: macos-latest
+            checksums: sha256,sha512,sha1,md5
             target: universal-apple-darwin
             build_tool: cargo
           - os: windows-latest
@@ -86,7 +92,7 @@ jobs:
           bin: test-crate
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build_tool }}
-          checksum: b2,sha256,sha512,sha1,md5
+          checksum: ${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}
           tar: all
           zip: all
           manifest-path: test-crate/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,10 @@ jobs:
           printf 'outputs.tar should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
 
-          for hash_type in ${ ${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}//,/ }; do
+          matrix_checksums=${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}
+          hash_types=${matrix_checksums//,/}
+
+          for hash_type in $hash_types; do
               printf "outputs.%s should be a file\n" "$hash_type"
               test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
 
           matrix_checksums=${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}
-          hash_types=${matrix_checksums//,/}
+          hash_types=${matrix_checksums//,/ }
 
           for hash_type in $hash_types; do
               printf "outputs.%s should be a file\n" "$hash_type"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,5 @@ jobs:
 
           for hash_type in $hash_types; do
               printf "outputs.%s should be a file\n" "$hash_type"
-              test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
+              test -f "${{ steps.upload-rust-binary-action.outputs }}.$hash_type"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,17 +110,7 @@ jobs:
           printf 'outputs.tar should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
 
-          printf 'outputs.b2 should be a file\n'
-          test -f "${{ steps.upload-rust-binary-action.outputs.b2 }}"
-
-          printf 'outputs.sha256 should be a file\n'
-          test -f "${{ steps.upload-rust-binary-action.outputs.sha256 }}"
-
-          printf 'outputs.sha512 should be a file\n'
-          test -f "${{ steps.upload-rust-binary-action.outputs.sha512 }}"
-
-          printf 'outputs.sha1 should be a file\n'
-          test -f "${{ steps.upload-rust-binary-action.outputs.sha1 }}"
-
-          printf 'outputs.md5 should be a file\n'
-          test -f "${{ steps.upload-rust-binary-action.outputs.md5 }}"
+          for hash_type in ${ ${{ matrix.checksums }}//,/ }; do
+              printf "outputs.%s should be a file\n" "$hash_type"
+              test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,5 @@ jobs:
 
           for hash_type in $hash_types; do
               printf "outputs.%s should be a file\n" "$hash_type"
-              test -f "${{ steps.upload-rust-binary-action.outputs }}.$hash_type"
+              test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           printf 'outputs.tar should be a file\n'
           test -f "${{ steps.upload-rust-binary-action.outputs.tar }}"
 
-          for hash_type in ${ ${{ matrix.checksums }}//,/ }; do
+          for hash_type in ${ ${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}//,/ }; do
               printf "outputs.%s should be a file\n" "$hash_type"
               test -f "${{ steps.upload-rust-binary-action.outputs.$hash_type }}"
           done

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Currently, this action is basically intended to be used in combination with an a
 | no-default-features | false        | Whether to disable cargo build default features                                              | Boolean | `false`        |
 | tar                 | false        | On which platform to distribute the `.tar.gz` file (all, unix, windows, or none)             | String  | `unix`         |
 | zip                 | false        | On which platform to distribute the `.zip` file (all, unix, windows, or none)                | String  | `windows`      |
-| checksum            | false        | Comma-separated list of algorithms to be used for checksum (sha256, sha512, sha1, or md5)    | String  |                |
+| checksum            | false        | Comma-separated list of algorithms to be used for checksum (b2, sha256, sha512, sha1, or md5) | String  |                |
 | include             | false        | Comma-separated list of additional files to be included to the archive                       | String  |                |
 | asset               | false        | Comma-separated list of additional files to be uploaded separately                           | String  |                |
 | leading-dir         | false        | Whether to create the leading directory in the archive or not                                | Boolean | `false`        |
@@ -69,6 +69,7 @@ Currently, this action is basically intended to be used in combination with an a
 | archive | Archive base name.           |
 | zip     | `.zip` archive file name.    |
 | tar     | `.tar.gz` archive file name. |
+| b2      | BLAKE2 checksum file name.   |
 | sha256  | SHA256 checksum file name.   |
 | sha512  | SHA512 checksum file name.   |
 | sha1    | SHA1 checksum file name.     |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Currently, this action is basically intended to be used in combination with an a
 | no-default-features | false        | Whether to disable cargo build default features                                              | Boolean | `false`        |
 | tar                 | false        | On which platform to distribute the `.tar.gz` file (all, unix, windows, or none)             | String  | `unix`         |
 | zip                 | false        | On which platform to distribute the `.zip` file (all, unix, windows, or none)                | String  | `windows`      |
-| checksum            | false        | Comma-separated list of algorithms to be used for checksum (b2, sha256, sha512, sha1, or md5) | String  |                |
+| checksum            | false        | Comma-separated list of algorithms to be used for checksum (b2, sha256, sha512, sha1, or md5).<br>Note: b2 is not available by default on macOS, install `b2sum` to use it. | String  |                |
 | include             | false        | Comma-separated list of additional files to be included to the archive                       | String  |                |
 | asset               | false        | Comma-separated list of additional files to be uploaded separately                           | String  |                |
 | leading-dir         | false        | Whether to create the leading directory in the archive or not                                | Boolean | `false`        |

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     description: Alias for 'build-tool'
     required: false
   checksum:
-    description: Comma-separated list of algorithms to be used for checksum (sha256, sha512, sha1, or md5)
+    description: Comma-separated list of algorithms to be used for checksum (b2, sha256, sha512, sha1, or md5)
     required: false
   token:
     description: >
@@ -119,6 +119,9 @@ outputs:
   tar:
     description: '.tar.gz archive file name'
     value: ${{ steps.upload-rust-binary-action.outputs.tar }}
+  b2:
+    description: 'BLAKE2 checksum file name'
+    value: ${{ steps.upload-rust-binary-action.outputs.b2 }}
   sha256:
     description: 'SHA256 checksum file name'
     value: ${{ steps.upload-rust-binary-action.outputs.sha256 }}

--- a/main.sh
+++ b/main.sh
@@ -145,8 +145,8 @@ if [[ -n "${checksum}" ]]; then
     while read -rd,; do
         checksums+=("${REPLY}")
         case "${REPLY}" in
-            sha256 | sha512 | sha1 | md5) ;;
-            *) bail "'checksum' input option must be 'sha256', 'sha512', 'sha1', or 'md5': '${REPLY}'" ;;
+            b2 | sha256 | sha512 | sha1 | md5) ;;
+            *) bail "'checksum' input option must be 'b2', 'sha256', 'sha512', 'sha1', or 'md5': '${REPLY}'" ;;
         esac
     done <<<"${checksum},"
 fi
@@ -489,6 +489,9 @@ for checksum in ${checksums[@]+"${checksums[@]}"}; do
         # GitHub-hosted macOS runner does not install GNU Coreutils by default.
         # https://github.com/actions/runner-images/issues/90
         case "${checksum}" in
+            b2)
+                bail "checksum for '${checksum}' requires '${checksum}sum' command; consider installing it"
+                ;;
             sha*)
                 if type -P shasum >/dev/null; then
                     shasum -a "${checksum#sha}" "${assets[@]}" >"${archive}.${checksum}"


### PR DESCRIPTION
BLAKE2 checksums have been part of coreutils [since 2016](https://github.com/coreutils/coreutils/commit/ea94589e9ef02624a3837f97f80efd7d3dcf56bf). BLAKE2 is considered an [overall better](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2) hash function compared to MD5 and SHA1/2/3. Moreover, b2 is the [preferred checksum for integrity checks in Arch packages](https://wiki.archlinux.org/title/PKGBUILD#Integrity).