### PR TITLE
add 'locked' input

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Currently, this action is basically intended to be used in combination with an a
 | codesign            | false        | Sign build products using `codesign` on macOS                                                | String  |                |
 | codesign-prefix     | false        | Prefix for the `codesign` identifier on macOS                                                | String  |                |
 | codesign-options    | false        | Specifies a set of option flags to be embedded in the code signature on macOS. See the `codesign` manpage for details. | String | |
+| locked              | false        | Build with `cargo --locked`                                                                  | Boolean | `false`        |
 
 \[1] Required one of `token` input option or `GITHUB_TOKEN` environment variable. Not required when `dry-run` input option is set to `true`.<br>
 \[2] This is optional but it is recommended that this always be set to clarify which target you are building for if macOS is included in the matrix because GitHub Actions changed the default architecture of macos-latest since macos-14.<br>

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   features:
     description: Comma-separated list of cargo build features to enable
     required: false
+  locked:
+    description: Whether to build with `cargo --locked`
+    required: false
+    default: 'false'
   no-default-features:
     description: Whether to disable cargo build default features
     required: false
@@ -149,6 +153,7 @@ runs:
         INPUT_ARCHIVE: ${{ inputs.archive }}
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_FEATURES: ${{ inputs.features }}
+        INPUT_LOCKED: ${{ inputs.locked }}
         INPUT_NO_DEFAULT_FEATURES: ${{ inputs.no-default-features || inputs.no_default_features }}
         INPUT_MANIFEST_PATH: ${{ inputs.manifest-path || inputs.manifest_path }}
         INPUT_TAR: ${{ inputs.tar }}

--- a/main.sh
+++ b/main.sh
@@ -94,6 +94,13 @@ case "${no_default_features}" in
     *) bail "'no-default-features' input option must be 'true' or 'false': '${no_default_features}'" ;;
 esac
 
+build_locked="${INPUT_LOCKED:-}"
+case "${build_locked}" in
+    true) build_locked=1 ;;
+    false) build_locked='' ;;
+    *) bail "'locked' input option must be 'true' or 'false': '${build_locked}'" ;;
+esac
+
 bin_name="${INPUT_BIN:?}"
 bin_names=()
 if [[ -n "${bin_name}" ]]; then
@@ -267,6 +274,9 @@ if [[ -n "${features}" ]]; then
 fi
 if [[ -n "${no_default_features}" ]]; then
     build_options+=(--no-default-features)
+fi
+if [[ -n "${build_locked}" ]]; then
+    build_options+=(--locked)
 fi
 metadata_options=(--format-version=1 --no-deps)
 manifest_path="${INPUT_MANIFEST_PATH:-}"


### PR DESCRIPTION
Implements #88.
When set, this adds --locked to the build invocation.

Closes https://github.com/taiki-e/upload-rust-binary-action/issues/88