### PR TITLE
Support tar-bz2 and add tar-gz as alias for tar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           workspace: ${{ matrix.workspace || 'false' }}
           checksum: ${{ matrix.checksums || 'b2,sha256,sha512,sha1,md5' }}
           tar: all
+          tar-bz2: all
           tar-xz: all
           zip: all
           manifest-path: test-crate/Cargo.toml
@@ -117,14 +118,26 @@ jobs:
           printf 'outputs.archive should not be empty\n'
           test -n "${OUTPUT_ARCHIVE}"
 
-          printf 'outputs.zip should be a file\n'
+          printf 'outputs.zip should be a zip file\n'
           test -f "${OUTPUT_ZIP}"
+          file "${OUTPUT_ZIP}" | grep -F 'Zip archive data'
 
-          printf 'outputs.tar should be a file\n'
+          printf 'outputs.tar should be a gz file\n'
           test -f "${OUTPUT_TAR}"
+          file "${OUTPUT_TAR}" | grep -F 'gzip compressed data'
 
-          printf 'outputs.tar-xz should be a file\n'
+          printf 'outputs.tar-gz should be a gz file\n'
+          test -f "${OUTPUT_TAR_GZ}"
+          file "${OUTPUT_TAR_GZ}" | grep -F 'gzip compressed data'
+          [[ "${OUTPUT_TAR}" == "${OUTPUT_TAR_GZ}" ]] || exit 1
+
+          printf 'outputs.tar-bz2 should be a bzip2 file\n'
+          test -f "${OUTPUT_TAR_BZ2}"
+          file "${OUTPUT_TAR_BZ2}" | grep -F 'bzip2 compressed data'
+
+          printf 'outputs.tar-xz should be a xz file\n'
           test -f "${OUTPUT_TAR_XZ}"
+          file "${OUTPUT_TAR_XZ}" | grep -F 'XZ compressed data'
 
           printf 'outputs.sha256 should be a file\n'
           test -f "${OUTPUT_SHA256}"
@@ -141,6 +154,8 @@ jobs:
           OUTPUT_ARCHIVE: ${{ steps.upload-rust-binary-action.outputs.archive }}
           OUTPUT_ZIP: ${{ steps.upload-rust-binary-action.outputs.zip }}
           OUTPUT_TAR: ${{ steps.upload-rust-binary-action.outputs.tar }}
+          OUTPUT_TAR_GZ: ${{ steps.upload-rust-binary-action.outputs.tar-gz }}
+          OUTPUT_TAR_BZ2: ${{ steps.upload-rust-binary-action.outputs.tar-bz2 }}
           OUTPUT_TAR_XZ: ${{ steps.upload-rust-binary-action.outputs.tar-xz }}
           OUTPUT_SHA256: ${{ steps.upload-rust-binary-action.outputs.sha256 }}
           OUTPUT_SHA512: ${{ steps.upload-rust-binary-action.outputs.sha512 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `tar-bz2` input option to upload `.tar.bz2` archive. ([#113](https://github.com/taiki-e/upload-rust-binary-action/pull/113))
+
+- Add `tar-gz` input option as an alias for `tar` input option for consistency with `tar-bz2` and `tar-xz` input options. ([#113](https://github.com/taiki-e/upload-rust-binary-action/pull/113))
+
 ## [1.29.1] - 2026-03-18
 
 - Fix missing default value for `all-features` causing build errors. ([#114](https://github.com/taiki-e/upload-rust-binary-action/pull/114), thanks @ftnfurina)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Currently, this action is basically intended to be used in combination with an a
 | package | | Package names to build (whitespace or comma separated list) | String | |
 | workspace | | Whether to build with `--workspace` flag | Boolean | `false` |
 | locked | | Whether to build with `--locked` flag | Boolean | `false` |
-| tar | | On which platform to distribute the `.tar.gz` file (all, unix, windows, or none) | String | `unix` |
+| tar-gz | | On which platform to distribute the `.tar.gz` file (all, unix, windows, or none) | String | `unix` |
+| tar | | Alias for `tar-gz` input option | String | |
+| tar-bz2 | | On which platform to distribute the `.tar.bz2` file (all, unix, windows, or none) | String | `none` |
 | tar-xz | | On which platform to distribute the `.tar.xz` file (all, unix, windows, or none) | String | `none` |
 | zip | | On which platform to distribute the `.zip` file (all, unix, windows, or none) | String | `windows` |
 | checksum | | Algorithms to be used for checksum (b2, sha256, sha512, sha1, or md5) (whitespace or comma separated list).<br>Note: b2 is not available by default on macOS, install `b2sum` to use it. | String | |
@@ -74,7 +76,9 @@ Currently, this action is basically intended to be used in combination with an a
 | ---- | ----------- |
 | archive | Archive base name. |
 | zip | `.zip` archive file name. |
-| tar | `.tar.gz` archive file name. |
+| tar-gz | `.tar.gz` archive file name. |
+| tar | Alias for `tar-gz` output. |
+| tar-bz2 | `.tar.bz2` archive file name. |
 | tar-xz | `.tar.xz` archive file name. |
 | b2 | BLAKE2 checksum file name. |
 | sha256 | SHA256 checksum file name. |
@@ -207,7 +211,7 @@ jobs:
           # (optional) On which platform to distribute the `.tar.gz` file.
           # [default value: unix]
           # [possible values: all, unix, windows, none]
-          tar: unix
+          tar-gz: unix
           # (optional) On which platform to distribute the `.zip` file.
           # [default value: windows]
           # [possible values: all, unix, windows, none]
@@ -319,7 +323,7 @@ jobs:
           # (optional) On which platform to distribute the `.tar.gz` file.
           # [default value: unix]
           # [possible values: all, unix, windows, none]
-          tar: unix
+          tar-gz: unix
           # (optional) On which platform to distribute the `.zip` file.
           # [default value: windows]
           # [possible values: all, unix, windows, none]

--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,18 @@ inputs:
   manifest_path:
     description: Alias for 'manifest-path'
     required: false
-  tar:
+  tar-gz:
     description: On which platform to distribute the `.tar.gz` file (all, unix, windows, or none)
     required: false
     default: 'unix'
+  tar:
+    description: Alias for 'tar-gz'
+    required: false
+    default: ''
+  tar-bz2:
+    description: On which platform to distribute the `.tar.bz2` file (all, unix, windows, or none)
+    required: false
+    default: 'none'
   tar-xz:
     description: On which platform to distribute the `.tar.xz` file (all, unix, windows, or none)
     required: false
@@ -108,13 +116,13 @@ inputs:
 
       Note that some errors are downgraded to warnings in this mode.
     required: false
+  dry_run:
+    description: Alias for 'dry-run'
+    required: false
+    default: 'false'
   dry-run-intended:
     description: >
       Suppress informational warnings for `dru-run` keeping the rest
-    required: false
-    default: 'false'
-  dry_run:
-    description: Alias for 'dry-run'
     required: false
     default: 'false'
   codesign:
@@ -135,31 +143,37 @@ inputs:
 
 outputs:
   archive:
-    description: 'Archive base name'
+    description: Archive base name
     value: ${{ steps.upload-rust-binary-action.outputs.archive }}
   zip:
-    description: '.zip archive file name'
+    description: .zip archive file name
     value: ${{ steps.upload-rust-binary-action.outputs.zip }}
   tar:
-    description: '.tar.gz archive file name'
-    value: ${{ steps.upload-rust-binary-action.outputs.tar }}
+    description: Alias for 'tar-gz'
+    value: ${{ steps.upload-rust-binary-action.outputs.tar-gz }}
+  tar-gz:
+    description: .tar.gz archive file name
+    value: ${{ steps.upload-rust-binary-action.outputs.tar-gz }}
+  tar-bz2:
+    description: .tar.bz2 archive file name
+    value: ${{ steps.upload-rust-binary-action.outputs.tar-bz2 }}
   tar-xz:
-    description: '.tar.xz archive file name'
+    description: .tar.xz archive file name
     value: ${{ steps.upload-rust-binary-action.outputs.tar-xz }}
   b2:
-    description: 'BLAKE2 checksum file name'
+    description: BLAKE2 checksum file name
     value: ${{ steps.upload-rust-binary-action.outputs.b2 }}
   sha256:
-    description: 'SHA256 checksum file name'
+    description: SHA256 checksum file name
     value: ${{ steps.upload-rust-binary-action.outputs.sha256 }}
   sha512:
-    description: 'SHA512 checksum file name'
+    description: SHA512 checksum file name
     value: ${{ steps.upload-rust-binary-action.outputs.sha512 }}
   sha1:
-    description: 'SHA1 checksum file name'
+    description: SHA1 checksum file name
     value: ${{ steps.upload-rust-binary-action.outputs.sha1 }}
   md5:
-    description: 'MD5 checksum file name'
+    description: MD5 checksum file name
     value: ${{ steps.upload-rust-binary-action.outputs.md5 }}
 
 # Note:
@@ -182,7 +196,8 @@ runs:
         INPUT_WORKSPACE: ${{ inputs.workspace }}
         INPUT_LOCKED: ${{ inputs.locked }}
         INPUT_MANIFEST_PATH: ${{ inputs.manifest-path || inputs.manifest_path }}
-        INPUT_TAR: ${{ inputs.tar }}
+        INPUT_TAR_GZ: ${{ inputs.tar || inputs.tar-gz }}
+        INPUT_TAR_BZ2: ${{ inputs.tar-bz2 }}
         INPUT_TAR_XZ: ${{ inputs.tar-xz }}
         INPUT_ZIP: ${{ inputs.zip }}
         INPUT_INCLUDE: ${{ inputs.include }}

--- a/main.sh
+++ b/main.sh
@@ -97,12 +97,17 @@ tag="${ref#refs/tags/}"
 features="${INPUT_FEATURES:-}"
 archive="${INPUT_ARCHIVE:?}"
 
-if [[ ! "${INPUT_TAR}" =~ ^(all|unix|windows|none)$ ]]; then
-  bail "invalid input 'tar': ${INPUT_TAR}"
-elif [[ ! "${INPUT_TAR_XZ}" =~ ^(all|unix|windows|none)$ ]]; then
-  bail "invalid input 'tar-xz': ${INPUT_TAR_XZ}"
-elif [[ ! "${INPUT_ZIP}" =~ ^(all|unix|windows|none)$ ]]; then
-  bail "invalid input 'zip': ${INPUT_ZIP}"
+if [[ ! "${INPUT_TAR_GZ}" =~ ^(all|unix|windows|none)$ ]]; then
+  bail "invalid input for 'tar' / 'tar-gz' input option: ${INPUT_TAR_GZ}"
+fi
+if [[ ! "${INPUT_TAR_BZ2}" =~ ^(all|unix|windows|none)$ ]]; then
+  bail "invalid input for 'tar-bz2' input option: ${INPUT_TAR_BZ2}"
+fi
+if [[ ! "${INPUT_TAR_XZ}" =~ ^(all|unix|windows|none)$ ]]; then
+  bail "invalid input for 'tar-xz' input option: ${INPUT_TAR_XZ}"
+fi
+if [[ ! "${INPUT_ZIP}" =~ ^(all|unix|windows|none)$ ]]; then
+  bail "invalid input for 'zip' input option: ${INPUT_ZIP}"
 fi
 
 leading_dir="${INPUT_LEADING_DIR:-}"
@@ -458,7 +463,8 @@ case "${host_os}" in
     ;;
 esac
 
-if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] \
+if [[ "${INPUT_TAR_GZ/all/${platform}}" == "${platform}" ]] \
+  || [[ "${INPUT_TAR_BZ2/all/${platform}}" == "${platform}" ]] \
   || [[ "${INPUT_TAR_XZ/all/${platform}}" == "${platform}" ]] \
   || [[ "${INPUT_ZIP/all/${platform}}" == "${platform}" ]]; then
   cwd=$(pwd)
@@ -489,17 +495,29 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] \
     # /${archive}
     # /${archive}/${bins}
     # /${archive}/${includes}
-    if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]]; then
+    if [[ "${INPUT_TAR_GZ/all/${platform}}" == "${platform}" ]]; then
       assets+=("${archive}.tar.gz")
 
       if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        printf 'tar=%s.tar.gz\n' "${archive}" >>"${GITHUB_OUTPUT}"
+        printf 'tar-gz=%s.tar.gz\n' "${archive}" >>"${GITHUB_OUTPUT}"
       else
-        warn "GITHUB_OUTPUT is not set; skip setting the 'tar' output"
-        printf 'tar: %s.tar.gz\n' "${archive}"
+        warn "GITHUB_OUTPUT is not set; skip setting the 'tar' / 'tar-gz' output"
+        printf 'tar-gz: %s.tar.gz\n' "${archive}"
       fi
 
       x tar acf "${cwd}/${archive}.tar.gz" "${archive}"
+    fi
+    if [[ "${INPUT_TAR_BZ2/all/${platform}}" == "${platform}" ]]; then
+      assets+=("${archive}.tar.bz2")
+
+      if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf 'tar-bz2=%s.tar.bz2\n' "${archive}" >>"${GITHUB_OUTPUT}"
+      else
+        warn "GITHUB_OUTPUT is not set; skip setting the 'tar-bz2' output"
+        printf 'tar-bz2: %s.tar.bz2\n' "${archive}"
+      fi
+
+      x tar acf "${cwd}/${archive}.tar.bz2" "${archive}"
     fi
     if [[ "${INPUT_TAR_XZ/all/${platform}}" == "${platform}" ]]; then
       assets+=("${archive}.tar.xz")
@@ -535,17 +553,29 @@ if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]] \
     # /${bins}
     # /${includes}
     pushd -- "${archive}" >/dev/null
-    if [[ "${INPUT_TAR/all/${platform}}" == "${platform}" ]]; then
+    if [[ "${INPUT_TAR_GZ/all/${platform}}" == "${platform}" ]]; then
       assets+=("${archive}.tar.gz")
 
       if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        printf 'tar=%s.tar.gz\n' "${archive}" >>"${GITHUB_OUTPUT}"
+        printf 'tar-gz=%s.tar.gz\n' "${archive}" >>"${GITHUB_OUTPUT}"
       else
-        warn "GITHUB_OUTPUT is not set; skip setting the 'tar' output"
-        printf 'tar: %s.tar.gz\n' "${archive}"
+        warn "GITHUB_OUTPUT is not set; skip setting the 'tar' / 'tar-gz' output"
+        printf 'tar-gz: %s.tar.gz\n' "${archive}"
       fi
 
       x tar acf "${cwd}/${archive}.tar.gz" "${filenames[@]}"
+    fi
+    if [[ "${INPUT_TAR_BZ2/all/${platform}}" == "${platform}" ]]; then
+      assets+=("${archive}.tar.bz2")
+
+      if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf 'tar-bz2=%s.tar.bz2\n' "${archive}" >>"${GITHUB_OUTPUT}"
+      else
+        warn "GITHUB_OUTPUT is not set; skip setting the 'tar-bz2' output"
+        printf 'tar-bz2: %s.tar.bz2\n' "${archive}"
+      fi
+
+      x tar acf "${cwd}/${archive}.tar.bz2" "${filenames[@]}"
     fi
     if [[ "${INPUT_TAR_XZ/all/${platform}}" == "${platform}" ]]; then
       assets+=("${archive}.tar.xz")


### PR DESCRIPTION
Changes:

- Add `tar-bz2` input option to upload `.tar.bz2` archive. 

- Add `tar-gz` input option as an alias for `tar` input option for consistency with `tar-bz2` and `tar-xz` input options.
